### PR TITLE
Fix cargo deny issues and enables cargo deny on ci/cd

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,4 +23,4 @@ jobs:
       - run: cargo test --verbose -- --ignored
       - run: cargo bench --no-run
       - run: cargo audit --deny warnings
-      # - uses: EmbarkStudios/cargo-deny-action@v1 # cargo deny check
+      - uses: EmbarkStudios/cargo-deny-action@v1 # cargo deny check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
+3. Ensure local tests and validations pass. You can run `./scripts/build_and_test.sh` to validate your changes locally before submitting a PR.
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.100"
 serde_repr = "0.1.16"
 sha256 = "1.3.0"
 tokio = { version = "1.0", features = ["full", "signal", "sync", "parking_lot"] }
-uuid = {version = "1.4.1", features = ["v4"] }
+uuid = { version = "1.4.1", features = ["v4"] }
 
 # Error, Logging, Tracing
 thiserror = "1.0.41"
@@ -35,4 +35,3 @@ cedar-policy-validator = "2.3.0"
 
 [dev-dependencies]
 tempfile = "3.8.0"
-

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,15 @@ ignore = []
 [bans]
 multiple-versions = "deny"
 deny = []
-skip = []
+skip = [
+    { name = "syn", version = "=1.0.109" }, # old dependency from derive_builder
+    { name = "darling", version = "=0.14.4" }, # old dependency from derive_builder
+    { name = "darling_macro", version = "=0.14.4" }, # old dependency from derive_builder
+    { name = "darling_core", version = "=0.14.4" }, # old dependency from derive_builder
+    { name = "bitflags", version = "=1.3.2" }, # old transitive dependency from cedar_policy_core
+    { name = "regex-syntax", version = "<=0.7.5" }, # old transitive dependency from cedar_policy_core
+    { name = "redox_syscall", version = "=0.2.16" }, # old transitive dependency from cedar_policy_core
+]
 skip-tree = []
 
 [sources]
@@ -28,7 +36,7 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "MIT",
-    "BSD-3-Clause",
-    "ISC",
+    "Unicode-DFS-2016",
+    "CC0-1.0",
 ]
 exceptions = []

--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+rustup update stable && rustup default stable && \
+cargo fmt --all --check && \
+RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose && \
+cargo doc --all-features --no-deps && \
+cargo clippy --all-features && \
+cargo test --verbose && \
+# cargo test --verbose --features integration-tests && \
+cargo test --verbose --no-default-features && \
+cargo test --verbose -- --ignored && \
+cargo bench --no-run && \
+cargo audit --deny warnings && \
+cargo deny check


### PR DESCRIPTION
*Issue #, if available:* #3

*Description of changes:* Fix cargo deny issues caused by dependencies. Enables cargo deny check validation in CI/CD.

Also creates a bash script for doing the same CI/CD validation locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
