### PR TITLE
Make AuthZ logging opt-in

### DIFF
--- a/src/public/log/mod.rs
+++ b/src/public/log/mod.rs
@@ -54,37 +54,21 @@ pub enum Format {
     Unknown,
 }
 
-#[derive(Builder, Eq, PartialEq, Debug, Clone)]
+#[derive(Builder, Eq, PartialEq, Debug, Clone, Default)]
 #[builder(pattern = "owned", default, setter(into))]
 #[allow(clippy::struct_excessive_bools)]
 /// The `FieldSet` specifies which fields are to be logged
 pub struct FieldSet {
     /// A boolean specifying whether the principal field is to be logged
-    #[builder(default = "true")]
     pub principal: bool,
     /// A boolean specifying whether the resource field is to be logged
-    #[builder(default = "true")]
     pub resource: bool,
     /// A boolean specifying whether the action field is to be logged
-    #[builder(default = "true")]
     pub action: bool,
     /// A boolean specifying whether the context field is to be logged
-    #[builder(default = "true")]
     pub context: bool,
     /// A variant of the `FieldLevel` enum specifying which entity fields are to be logged
     pub entities: FieldLevel<Entities>,
-}
-
-impl Default for FieldSet {
-    fn default() -> Self {
-        Self {
-            principal: true,
-            resource: true,
-            action: true,
-            context: true,
-            entities: FieldLevel::default(),
-        }
-    }
 }
 
 /// The `FieldLevel` enum is used to specify which fields are to be logged from a entities object.
@@ -93,9 +77,9 @@ impl Default for FieldSet {
 #[derive(Default, Eq, PartialEq, Debug, Clone)]
 #[non_exhaustive]
 pub enum FieldLevel<T> {
+    #[default]
     /// No fields are logged
     None,
-    #[default]
     /// All fields are logged
     All,
     /// Only the provided set of fields are logged.
@@ -130,7 +114,7 @@ mod test {
         let log_configuration_two = ConfigBuilder::default().build().unwrap();
         let log_configuration_three = ConfigBuilder::default()
             .format(Format::OpenCyberSecurityFramework)
-            .field_set(FieldSetBuilder::default().principal(false).build().unwrap())
+            .field_set(FieldSetBuilder::default().principal(true).build().unwrap())
             .build()
             .unwrap();
 
@@ -202,9 +186,10 @@ mod test {
     #[test]
     fn field_set_defaults() {
         let field_set = FieldSet::default();
-        assert!(field_set.context);
-        assert!(field_set.principal);
-        assert!(field_set.action);
-        assert!(field_set.resource);
+        assert!(!field_set.context);
+        assert!(!field_set.principal);
+        assert!(!field_set.action);
+        assert!(!field_set.resource);
+        assert_eq!(field_set.entities, FieldLevel::None);
     }
 }

--- a/src/public/log/schema.rs
+++ b/src/public/log/schema.rs
@@ -1353,20 +1353,11 @@ mod test {
         let field_set = FieldSetBuilder::default().build().unwrap();
         let filtered_request = filter_request(&request, &entities, &field_set);
 
-        assert!(matches!(
-            filtered_request.principal,
-            EntityComponent::Concrete(_)
-        ));
-        assert!(matches!(
-            filtered_request.resource,
-            EntityComponent::Concrete(_)
-        ));
-        assert!(matches!(
-            filtered_request.action,
-            EntityComponent::Concrete(_)
-        ));
-        assert!(filtered_request.context.is_some());
-        assert!(filtered_request.entities.is_some());
+        assert_eq!(filtered_request.principal, EntityComponent::None);
+        assert_eq!(filtered_request.action, EntityComponent::None);
+        assert_eq!(filtered_request.resource, EntityComponent::None);
+        assert!(filtered_request.context.is_none());
+        assert!(filtered_request.entities.is_none());
     }
 
     #[test]
@@ -1405,8 +1396,8 @@ mod test {
         let entities = create_mock_entities();
         let filter_fn = |_entities: &Entities| -> Entities { Entities::empty() };
         let field_set = FieldSetBuilder::default()
-            .principal(false)
-            .context(false)
+            .principal(true)
+            .context(true)
             .entities(FieldLevel::Custom(filter_fn))
             .build()
             .unwrap();
@@ -1414,16 +1405,13 @@ mod test {
         let filtered_request = filter_request(&request, &entities, &field_set);
 
         assert!(matches!(
-            filtered_request.resource,
+            filtered_request.principal,
             EntityComponent::Concrete(_)
         ));
-        assert!(matches!(filtered_request.principal, EntityComponent::None));
-        assert!(filtered_request.context.is_none());
+        assert!(matches!(filtered_request.action, EntityComponent::None));
+        assert!(matches!(filtered_request.resource, EntityComponent::None));
 
-        assert_eq!(
-            filtered_request.resource,
-            EntityComponent::Concrete(request.resource().cloned().unwrap()),
-        );
+        assert_eq!(filtered_request.context, Some(request.to_string()));
         assert_eq!(filtered_request.entities, Some(Entities::empty()));
     }
 

--- a/src/public/simple.rs
+++ b/src/public/simple.rs
@@ -214,7 +214,7 @@ mod test {
         assert!(result.is_ok());
         assert_eq!(result.unwrap().decision(), Decision::Deny);
         assert_eq!(authorizer.log_config.requester, DEFAULT_REQUESTER_NAME);
-        assert!(authorizer.log_config.field_set.principal);
+        assert!(!authorizer.log_config.field_set.principal);
     }
 
     #[derive(Debug, Default)]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/cedar-policy/cedar-local-agent/issues/12

*Description of changes:*
Changed the defaults of the logging config so that by default we do not log anything unless explicitly set by the user.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
