### PR TITLE
Added test case to check whether user input can affect log size

### DIFF
--- a/src/public/log/schema.rs
+++ b/src/public/log/schema.rs
@@ -1309,6 +1309,7 @@ mod test {
         assert!(matches!(log_result, _expected));
     }
 
+    /// This test proves that user request input is being redacted on `FieldSet::default()`
     #[test]
     fn validate_user_input_no_effect_on_log_size() {
         let response = generate_response(0, Decision::Allow);


### PR DESCRIPTION
## Description of changes

Added a test case to validate that the user's request and entities can't affect the size of the logging output on `FieldSet::default()`

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

NA

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
