### PR TITLE
Removed unused UpdateError

### DIFF
--- a/src/public/events/core.rs
+++ b/src/public/events/core.rs
@@ -109,7 +109,7 @@ pub fn file_inspector_task(
         /// Creates a new instance of the `FileChangeInspector`
         pub fn new(file_path: String) -> Self {
             Self {
-                /// This is the path to the file to monitor for changes.
+                // This is the path to the file to monitor for changes.
                 file_path,
                 hash: None,
             }

--- a/src/public/file/entity_provider.rs
+++ b/src/public/file/entity_provider.rs
@@ -77,20 +77,17 @@ pub enum ProviderError {
     /// Entities file is malformed in some way
     #[error("The Entities failed to be parsed at path: {0}")]
     EntitiesError(String),
-    /// When the file system entity provider cannot update it's data
-    #[error("The update provider failed to update the entities: {0}")]
-    UpdateError(#[source] UpdateProviderDataError),
 }
 
 /// A wrapper that wraps `EntitiesError` to map the error message
 struct EntitiesErrorWrapper {
-    /// This is the path to the file to load entities
+    // This is the path to the file to load entities
     entity_file_path: String,
 }
 
 /// A wrapper that wraps `SchemaParseError` to map the error message
 struct SchemaParseErrorWrapper {
-    /// This is the path to the file to load schema
+    // This is the path to the file to load schema
     schema_file_path: String,
 }
 
@@ -99,7 +96,7 @@ impl EntitiesErrorWrapper {
     /// Creates a new wrapper of the `EntitiesError`
     fn new(entity_file_path: String) -> Self {
         Self {
-            /// This is the path to the file to load entities.
+            // This is the path to the file to load entities.
             entity_file_path,
         }
     }
@@ -110,7 +107,7 @@ impl SchemaParseErrorWrapper {
     /// Creates a new wrapper of the `SchemaParseError`
     fn new(schema_file_path: String) -> Self {
         Self {
-            /// This is the path to the file to load schema.
+            // This is the path to the file to load schema.
             schema_file_path,
         }
     }

--- a/src/public/file/policy_set_provider.rs
+++ b/src/public/file/policy_set_provider.rs
@@ -68,9 +68,6 @@ pub enum ProviderError {
     /// Can't read from disk or find the file
     #[error("IO Error: {0}")]
     IOError(#[source] std::io::Error),
-    /// Failed to update the data async via the update provider
-    #[error("The update provider failed to update the policy set: {0}")]
-    UpdateError(#[source] UpdateProviderDataError),
 }
 
 /// A wrapper that wraps policy set `ParseError` to map the error message
@@ -84,7 +81,7 @@ impl ParseErrorWrapper {
     /// Creates a new wrapper of the `ParseErrors`
     fn new(policy_set_path: String) -> Self {
         Self {
-            /// This is the path to the file to load the policy set
+            // This is the path to the file to load the policy set
             policy_set_path,
         }
     }


### PR DESCRIPTION
## Description of changes

Removed unused UpdateError types from policy set provider and entity provider.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

Add a description on how the code changes were tested, if applicable.

Hint: run `./scripts/build_and_test.sh` script to validate your changes locally before submitting a PR.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
