### PR TITLE
Fix build script

### DIFF
--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -37,8 +37,8 @@ echo ">>>> cargo deny check" && \
 cargo deny check && \
 
 echo ">>>> Removing old test coverage artifacts" && \
-rm -rf target/coverage/ && mkdir target/coverage/ && \
-rm -rf target/private/profraw/ && mkdir target/private/profraw/ && \
+rm -rf target/coverage/ && mkdir -p target/coverage/ && \
+rm -rf target/private/profraw/ && mkdir -p target/private/profraw/ && \
 
 echo ">>>> Generating new test coverage profraw files" && \
 RUSTFLAGS="-Cinstrument-coverage" LLVM_PROFILE_FILE="target/private/profraw/%p-%m.profraw" cargo test && \


### PR DESCRIPTION
## Description of changes
Added `-p` flag to mkdir in build script to allow it to create the directories to store coverage info if they do not exist. Without this the build script will fail.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

Add a description on how the code changes were tested, if applicable.

Hint: run `./scripts/build_and_test.sh` script to validate your changes locally before submitting a PR.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
