### PR TITLE
Clarify confusion between Cedar and OCFS entity fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ let authorizer: Authorizer<PolicySetProvider, EntityProvider> = Authorizer::new(
 );
 ```
 
+Note: ``Authorizer`` ``log_config`` ``FieldSet::entities `` refers to the Cedar entities. 
+There is also an [OCSF](https://github.com/ocsf) field called [``entity``](https://github.com/cedar-policy/cedar-local-agent/blob/main/src/public/log/schema.rs#L86) which refers to the principal entity that is sending the request.
+
+This means that when ``Authorizer`` ``log_config`` ``FieldSet::entities`` is set to ``FieldLevel::None``, the OCSF entity will still be logged. 
+This is not a bug and is expected behaviour.
+
+For more examples of how to set up the authorization logging, see our [usage examples](https://github.com/cedar-policy/cedar-local-agent/tree/main/examples/tracing/authorization_log)
+
 ### Secure Logging Configuration:
 
 Using a `log::FieldSet` configuration that sets any cedar-related field (principal, action, resource, context, and entities) to `true` will result in that field being logged. 


### PR DESCRIPTION
## Description of changes

It is a little confusing that Cedar and OCFS both have fields called "entity" and this means users might think that the log configuration is not working as expected. This change adds some documentation to clarify that

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-local-agent` (e.g., changes to the signature of an
  existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-local-agent` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-local-agent`.
- [x ] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor
  version bumps).
- [ x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing
N/A
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
