### PR TITLE
Update cedar-policy and related crates to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,30 +232,31 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "2.4.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d91e3b10a0f7f2911774d5e49713c4d25753466f9e11d1cd2ec627f8a2dc857"
+checksum = "2bb36693ce767682abfffa846039cb9cb06438ea4da284b715956bacb066602d"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-validator",
- "itertools",
+ "itertools 0.12.0",
  "lalrpop-util",
+ "miette",
  "ref-cast",
  "serde",
  "serde_json",
+ "serde_with",
  "smol_str",
  "thiserror",
 ]
 
 [[package]]
 name = "cedar-policy-core"
-version = "2.4.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2315591c6b7e18f8038f0a0529f254235fd902b6c217aabc04f2459b0d9995"
+checksum = "c286d084e4e2d831756b54f417f644ea80946da97b644afee50a01b57e3af422"
 dependencies = [
  "either",
- "ipnet",
- "itertools",
+ "itertools 0.12.0",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
@@ -272,12 +273,12 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "2.4.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec0e42563572fa293bd371dc42a5f0c2778ed07e12285d22795381ba4e1e0d1"
+checksum = "249593c8caf3d9886de0dc3c95e4cc6a7fb83174c708935de7fa7caaff33e0c0"
 dependencies = [
  "cedar-policy-core",
- "itertools",
+ "itertools 0.12.0",
  "logos",
  "miette",
  "pretty",
@@ -287,12 +288,12 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-validator"
-version = "2.4.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e756e1b2a5da742ed97e65199ad6d0893e9aa4bd6b34be1de9e70bd1e6adc7df"
+checksum = "31df9ac3c89d418f3cdb6634492bb8c20e2ef13d5be5472773bea9daca7dd2ea"
 dependencies = [
  "cedar-policy-core",
- "itertools",
+ "itertools 0.12.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -412,7 +413,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -434,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -930,12 +931,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +946,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -981,7 +985,7 @@ dependencies = [
  "diff",
  "ena",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "lalrpop-util",
  "petgraph",
  "pico-args",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,10 @@ tracing-core = "0.1.31"
 tracing-subscriber = "0.3.17"
 
 # Cedar
-cedar-policy = "2.4.2"
-cedar-policy-core = "2.4.2"
-cedar-policy-formatter = "2.4.2"
-cedar-policy-validator = "2.4.2"
+cedar-policy = "3.0.0"
+cedar-policy-core = "3.0.0"
+cedar-policy-formatter = "3.0.0"
+cedar-policy-validator = "3.0.0"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/benches/data_gen/data_gen.rs
+++ b/benches/data_gen/data_gen.rs
@@ -59,6 +59,7 @@ fn main() {
             .cloned()
             .chain(actions.iter().cloned())
             .chain(resources.iter().cloned()),
+        None,
     )
     .unwrap();
     let entities_file = File::create(format!("{}.entities.json", file_name)).unwrap();

--- a/benches/data_gen/entities.rs
+++ b/benches/data_gen/entities.rs
@@ -15,12 +15,15 @@ fn generate_entity_uid(entity_type: EntityTypeName) -> EntityUid {
 pub fn generate_entities(num_entities: u32, entity_type: EntityTypeName) -> Entities {
     let mut entities: Vec<Entity> = Vec::new();
     for _ in 0..num_entities {
-        entities.push(Entity::new(
-            generate_entity_uid(entity_type.clone()),
-            HashMap::new(),
-            HashSet::new(),
-        ));
+        entities.push(
+            Entity::new(
+                generate_entity_uid(entity_type.clone()),
+                HashMap::new(),
+                HashSet::new(),
+            )
+            .unwrap(),
+        );
     }
 
-    Entities::from_entities(entities).unwrap()
+    Entities::from_entities(entities, None).unwrap()
 }

--- a/benches/is_authorized.rs
+++ b/benches/is_authorized.rs
@@ -14,7 +14,9 @@ fn construct_request() -> Request {
         Some("Action::\"request\"".parse().unwrap()),
         Some("Resource::\"request\"".parse().unwrap()),
         Context::empty(),
+        None,
     )
+    .unwrap()
 }
 
 fn construct_authorizer(num_policies: u32) -> Authorizer<PolicySetProvider, EntityProvider> {

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ skip = [
     { name = "darling_macro", version = "=0.14.4" }, # old dependency from derive_builder
     { name = "darling_core", version = "=0.14.4" }, # old dependency from derive_builder
     { name = "bitflags", version = "=1.3.2" }, # old transitive dependency from cedar_policy_core
+    { name = "itertools", version = "=0.10.5" }, # old transitive dependency from lalrpop and criterion
     { name = "regex-syntax", version = "<=0.7.5" }, # old transitive dependency from cedar_policy_core
     { name = "windows_aarch64_gnullvm", version = "=0.48.5" }, # old dependency from chrono,lalrpop
     { name = "windows_aarch64_msvc", version = "=0.48.5" }, # old dependency from chrono,lalrpop

--- a/examples/simple/main.rs
+++ b/examples/simple/main.rs
@@ -12,7 +12,9 @@ fn construct_request() -> Request {
         Some("Action::\"request\"".parse().unwrap()),
         Some("Resource::\"request\"".parse().unwrap()),
         Context::empty(),
+        None,
     )
+    .unwrap()
 }
 
 #[inline]

--- a/src/public/file/entity_provider.rs
+++ b/src/public/file/entity_provider.rs
@@ -316,12 +316,16 @@ mod test {
         assert!(provider.is_ok());
         assert!(provider
             .unwrap()
-            .get_entities(&Request::new(
-                Some(r#"User::"Eric""#.parse().unwrap()),
-                Some(r#"Action::"View""#.parse().unwrap()),
-                Some(r#"Box::"10""#.parse().unwrap()),
-                Context::empty(),
-            ))
+            .get_entities(
+                &Request::new(
+                    Some(r#"User::"Eric""#.parse().unwrap()),
+                    Some(r#"Action::"View""#.parse().unwrap()),
+                    Some(r#"Box::"10""#.parse().unwrap()),
+                    Context::empty(),
+                    None,
+                )
+                .unwrap()
+            )
             .await
             .is_ok());
     }

--- a/src/public/file/policy_set_provider.rs
+++ b/src/public/file/policy_set_provider.rs
@@ -245,12 +245,16 @@ mod test {
         assert!(provider.is_ok());
         assert!(provider
             .unwrap()
-            .get_policy_set(&Request::new(
-                Some(r#"User::"Adam""#.parse().unwrap()),
-                Some(r#"Action::"View""#.parse().unwrap()),
-                Some(r#"Box::"10""#.parse().unwrap()),
-                Context::empty(),
-            ))
+            .get_policy_set(
+                &Request::new(
+                    Some(r#"User::"Adam""#.parse().unwrap()),
+                    Some(r#"Action::"View""#.parse().unwrap()),
+                    Some(r#"Box::"10""#.parse().unwrap()),
+                    Context::empty(),
+                    None,
+                )
+                .unwrap()
+            )
             .await
             .is_ok());
     }

--- a/src/public/log/schema.rs
+++ b/src/public/log/schema.rs
@@ -196,7 +196,7 @@ impl OpenCyberSecurityFramework {
         let response_error: Vec<String> = response
             .diagnostics()
             .errors()
-            .map(|error| error.to_string())
+            .map(std::string::ToString::to_string)
             .collect();
         unmapped.insert(
             "evaluation_errors".to_string(),
@@ -1064,7 +1064,7 @@ mod test {
 
         let errors = (0..num_of_error)
             .map(|i| AuthorizationError::PolicyEvaluationError {
-                id: PolicyID::from_string(format!("policy{}", i)),
+                id: PolicyID::from_string(format!("policy{i}")),
                 error: EvaluationError::from(ExtensionFunctionLookupError::FuncDoesNotExist {
                     name: Name::parse_unqualified_name("foo").unwrap(),
                 }),

--- a/src/public/simple.rs
+++ b/src/public/simple.rs
@@ -134,6 +134,7 @@ where
                 .iter()
                 .chain(entities.iter())
                 .cloned(),
+            None,
         )
         .map_err(|e| AuthorizerError::General(Box::new(e)))?;
 
@@ -233,7 +234,9 @@ mod test {
                     Some(r#"Action::"View""#.parse().unwrap()),
                     Some(r#"Box::"10""#.parse().unwrap()),
                     Context::empty(),
-                ),
+                    None,
+                )
+                .unwrap(),
                 &Entities::empty(),
             )
             .await;
@@ -272,7 +275,9 @@ mod test {
                     Some(r#"Action::"View""#.parse().unwrap()),
                     Some(r#"Box::"2""#.parse().unwrap()),
                     Context::empty(),
-                ),
+                    None,
+                )
+                .unwrap(),
                 &Entities::empty(),
             )
             .await;
@@ -311,7 +316,9 @@ mod test {
                     Some(r#"Action::"View""#.parse().unwrap()),
                     Some(r#"Box::"3""#.parse().unwrap()),
                     Context::empty(),
-                ),
+                    None,
+                )
+                .unwrap(),
                 &Entities::empty(),
             )
             .await;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -405,6 +405,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[should_panic]
     async fn authorize_with_conflicting_input_entities() {
         let policy_set_provider = Arc::new(
             PolicySetProvider::new(
@@ -439,6 +440,7 @@ mod test {
         let schema_file = File::open("tests/data/sweets.schema.cedar.json").unwrap();
         let schema = Schema::from_file(schema_file).unwrap();
         let entities = Entities::from_json_file(entities_file, Some(&schema)).unwrap();
+        // This panics now due to enhanced entity validation in cedar-policy 3.0.0
         validate_requests_with_entities(
             &authorizer,
             &entities,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -406,7 +406,7 @@ mod test {
 
     #[tokio::test]
     #[should_panic]
-    async fn authorize_with_conflicting_input_entities() {
+    async fn authorize_with_duplicated_input_entities_should_panic() {
         let policy_set_provider = Arc::new(
             PolicySetProvider::new(
                 policy_set_provider::ConfigBuilder::default()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -26,7 +26,9 @@ mod test {
             Some(format!("Action::\"{action}\"").parse().unwrap()),
             Some(format!("Box::\"{resource}\"").parse().unwrap()),
             Context::empty(),
+            None,
         )
+        .unwrap()
     }
 
     fn requests_with_missing_entities() -> Vec<(Request, Decision)> {


### PR DESCRIPTION
## Description of changes

Update cedar-policy and related crates to 3.0.0. This was mostly just adding `Option<&Schema>` arguments to places where `Request::new()` is called.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing

Ran `./scripts/build_and_test.sh`. The only issue is with the current version zerocopy, which is addressed by #58.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
