### PR TITLE
Allow clippy::blocks_in_conditions lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,11 @@
     rustdoc::bare_urls,
     clippy::doc_markdown
 )]
-// FIXME: Rust 1.76 introduced a linting bug for `clippy::blocks_in_conditions`. Remove this lint from allow once fixed. 
-#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn, clippy::blocks_in_conditions)]
+// FIXME: Rust 1.76 introduced a linting bug for `clippy::blocks_in_conditions`. Remove this lint from allow once fixed.
+#![allow(
+    clippy::must_use_candidate,
+    clippy::missing_const_for_fn,
+    clippy::blocks_in_conditions
+)]
 
 pub mod public;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
     rustdoc::bare_urls,
     clippy::doc_markdown
 )]
-#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+// FIXME: Rust 1.76 introduced a linting bug for `clippy::blocks_in_conditions`. Remove this lint from allow once fixed. 
+#![allow(clippy::must_use_candidate, clippy::missing_const_for_fn, clippy::blocks_in_conditions)]
 
 pub mod public;


### PR DESCRIPTION
## Description of changes
In Rust 1.76 release there is a bug with clippy causing async fns that are decorated with `#[tracing::instrument(..)]` will trigger https://rust-lang.github.io/rust-clippy/master/index.html#/blocks_in_conditions. This is causing the nightly builds to fail. Temporarily disabling this lint until next rust release

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

## Testing
Ran failing build step locally after updating to rust 1.76 and making change

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
