### PR TITLE
Prep/1.1.0 - Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Cedar Local Agent Version: 1.1.0
 - Upgrade to Cedar dependencies to 3.0.0.
 - Added derive Clone to RefreshRate struct.
 - Add cause for entity and policy provider errors
+- Add support for partial evaluation
 
 ## 1.0.0 - 2023-12-14
 Cedar Local Agent Version: 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added derive Clone to RefreshRate struct. 
-- Add cause for entity and policy provider errors
 
 ### Added
 
 ### Changed
 
 ### Fixed
+
+## 1.1.0 - 2024-02-13
+Cedar Local Agent Version: 1.1.0
+- Upgrade to Cedar dependencies to 3.0.0.
+- Added derive Clone to RefreshRate struct.
+- Add cause for entity and policy provider errors
 
 ## 1.0.0 - 2023-12-14
 Cedar Local Agent Version: 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Cedar Local Agent Version: 1.1.0
 - Added derive Clone to RefreshRate struct.
 - Add cause for entity and policy provider errors
 - Add support for partial evaluation
+- Add better provider parsing error messages
 
 ## 1.0.0 - 2023-12-14
 Cedar Local Agent Version: 1.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-local-agent"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedar-local-agent"
 edition = "2021"
-version = "1.0.0"
+version = "1.1.0"
 license = "Apache-2.0"
 description = "Foundational library for creating Cedar-based asynchronous authorizers."
 keywords = ["cedar", "agent", "authorization", "policy", "security"]


### PR DESCRIPTION
## Description of changes
Bumping the version number to 1.1.0. Includes 3 additions:
- Upgrade to Cedar dependencies to 3.0.0.
- Added derive Clone to RefreshRate struct.
- Allow clippy::blocks_in_conditions lint
- Partial evaluation
- More detailed error messages

## Issue #, if available
#65, #62, #59. #64, #68

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x]  A backwards-compatible change requiring a minor version bump to cedar-local-agent (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- Updates the crate to a new version

## Testing

Ran `./scripts/build_and_test.sh` 

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
