### PR TITLE
Add better provider parsing errors messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 - Added derive Clone to RefreshRate struct. 
+- Add cause for entity and policy provider errors
 
 ### Added
 


### PR DESCRIPTION
## Description of changes
Added cause of error to Entity and Policy provider parsing errors 

## Issue #, if available
https://github.com/cedar-policy/cedar-local-agent/issues/67

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-local-agent` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor
  version bumps).

## Testing
Ran local build

Error difference
```
// before
EntitiesError("/var/folders/_g/9l0dzppx423c5j0x0b9z_qgm0000gs/T/.tmpXeRe8r")

// after
EntitiesError("/var/folders/_g/9l0dzppx423c5j0x0b9z_qgm0000gs/T/.tmpXeRe8r", Deserialization(Serde(Error("invalid type: map, expected a sequence", line: 1, column: 1)
```
