### PR TITLE
Prep 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## 1.1.0 - 2024-02-13
-Cedar Local Agent Version: 1.1.0
-- Upgrade to Cedar dependencies to 3.0.0.
+## 2.0.0 - 2024-03-13
+Cedar Local Agent Version: 2.0.0
+- Upgrade to Cedar dependencies to 3.1.0.
 - Added derive Clone to RefreshRate struct.
 - Add cause for entity and policy provider errors
 - Add support for partial evaluation

--- a/examples/simple_semver_check/.gitignore
+++ b/examples/simple_semver_check/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/examples/simple_semver_check/Cargo.toml
+++ b/examples/simple_semver_check/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 # Update the branch here when a new version is released
-cedar-local-agent = { git = "https://github.com/cedar-policy/cedar-local-agent.git", branch = "release/1.0.0" }
+cedar-local-agent = { path="../.." }
 # When creating a new release, update the branch here
-cedar-policy = "2.4.3"
-cedar-policy-core = "2.4.3"
+cedar-policy = "3.1.0"
+cedar-policy-core = "3.1.0"
 tokio = "1.36.0"

--- a/examples/simple_semver_check/src/main.rs
+++ b/examples/simple_semver_check/src/main.rs
@@ -14,7 +14,8 @@ fn construct_request() -> Request {
         Some("Action::\"request\"".parse().unwrap()),
         Some("Resource::\"request\"".parse().unwrap()),
         Context::empty(),
-    )
+        None
+    ).unwrap()
 }
 
 #[inline]


### PR DESCRIPTION
## Description of changes
Preparing for major version bump

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-local-agent` (e.g., changes to the signature of an
  existing API).

## Testing

Ran test script and simple_semver_check. The semver check required an update proving that this is a major version update. 

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
