### PR TITLE
Prepare for 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Update to Cedar 4 (requires breaking change)
-
 ### Changed
-
-- Remove dependency on `cedar-policy-core`, `cedar-policy-formatter`, and `cedar-policy-validator`.
-- Update `thiserror` and `derive_builder` versions
 
 ### Fixed
 
+## 3.0.0 2025-04-28
+- Update to Cedar 4 (requires breaking change)
+- Remove dependency on `cedar-policy-core`, `cedar-policy-formatter`, and `cedar-policy-validator`.
+- Update `thiserror` and `derive_builder` versions
 - Remove unused deps
 
 ## 2.0.0 - 2024-03-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-local-agent"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "async-trait",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedar-local-agent"
 edition = "2021"
-version = "2.0.0"
+version = "3.0.0"
 license = "Apache-2.0"
 description = "Foundational library for creating Cedar-based asynchronous authorizers."
 keywords = ["cedar", "agent", "authorization", "policy", "security"]

--- a/examples/simple_semver_check/Cargo.toml
+++ b/examples/simple_semver_check/Cargo.toml
@@ -11,6 +11,5 @@ edition = "2021"
 # Update the branch here when a new version is released
 cedar-local-agent = { path="../.." }
 # When creating a new release, update the branch here
-cedar-policy = "3.1.0"
-cedar-policy-core = "3.1.0"
+cedar-policy = "4"
 tokio = "1.36.0"

--- a/examples/simple_semver_check/src/main.rs
+++ b/examples/simple_semver_check/src/main.rs
@@ -4,15 +4,14 @@ use cedar_local_agent::public::file::entity_provider::EntityProvider;
 use cedar_local_agent::public::file::policy_set_provider::PolicySetProvider;
 use cedar_local_agent::public::file::{entity_provider, policy_set_provider};
 use cedar_local_agent::public::simple::{Authorizer, AuthorizerConfigBuilder};
-use cedar_policy::{Context, Entities, Request};
-use cedar_policy_core::authorizer::Decision;
+use cedar_policy::{Context, Entities, Request, Decision};
 use std::sync::Arc;
 
 fn construct_request() -> Request {
     Request::new(
-        Some("Principal::\"request\"".parse().unwrap()),
-        Some("Action::\"request\"".parse().unwrap()),
-        Some("Resource::\"request\"".parse().unwrap()),
+        "Principal::\"request\"".parse().unwrap(),
+        "Action::\"request\"".parse().unwrap(),
+        "Resource::\"request\"".parse().unwrap(),
         Context::empty(),
         None
     ).unwrap()


### PR DESCRIPTION
## Description of changes
New major release incorporating Cedar 4. See `CHANGELOG.md` for details. 

## Issue #, if available
#86 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-local-agent` (e.g., changes to the signature of an
  existing API).

## Testing

Ran the build and test script, ran the semver check, compiled latest version of avp local agent against this. 